### PR TITLE
Create borg backup dirs if nonexistent when running `snapborg init` [2/6]

### DIFF
--- a/snapborg/borg.py
+++ b/snapborg/borg.py
@@ -36,8 +36,13 @@ class BorgRepo:
         Initialize the borg repository
         """
         # TODO: should we really fail if repo already exists?
-        borg_init_invocation = ["init", "--encryption",
-                                self.encryption, self.repopath]
+        borg_init_invocation = [
+            "init",
+            "--encryption",
+            self.encryption,
+            "--make-parent-dirs",
+            self.repopath,
+        ]
         launch_borg(borg_init_invocation, self.passphrase,
                     print_output=self.is_interactive, dryrun=dryrun)
 


### PR DESCRIPTION
If directories don't exist when `snapborg init` is run, snapborg creates the directories instead of failing.