### PR TITLE
Quick code cleanup: backup error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ General options:
   --dryrun          Don't actually do anything
   --snapper-config  Only operate on a single snapper config
                     given by its name
+  -v                increase verbosity, can be repeated twice
 
 Commands:
   init          Initialize (create) the configured borg repositories

--- a/snapborg/commands/snapborg.py
+++ b/snapborg/commands/snapborg.py
@@ -139,24 +139,19 @@ def backup(cfg, snapper_configs, recreate, prune_old_backups, dryrun):
     """
     Backup all given snapper configs, optionally recreating the archives
     """
-    status_map = {}
+    failures = []
+
+    LOG.info("Backup results:")
     for config in snapper_configs:
         try:
             backup_config(config, recreate, dryrun)
-            status_map[config["name"]] = True
+            LOG.info("\t%s:\tOK", config["name"])
         except Exception as e:
-            status_map[config["name"]] = e
-    LOG.info("Backup results:")
-    has_error = False
-    for config_name, status in status_map.items():
-        if status is True:
-            LOG.info(f"\t{config_name}:\tOK")
-        else:
-            has_error = True
-            LOG.error(f"\t{config_name}: FAILED - {status}")
+            failures.append(e)
+            LOG.error("\t%s: FAILED - %s", config["name"], e)
 
-    if has_error:
-        raise Exception("Snapborg failed!")
+    if len(failures) > 0:
+        raise Exception(failures)
     elif prune_old_backups:
         prune(cfg, snapper_configs, dryrun)
 

--- a/snapborg/commands/snapborg.py
+++ b/snapborg/commands/snapborg.py
@@ -22,7 +22,7 @@ import yaml
 from ..borg import BorgRepo
 from ..retention import get_retained_snapshots
 from ..snapper import SnapperConfig
-from ..util import selective_merge, init_snapborg_logger
+from ..util import selective_merge, init_snapborg_logger, set_loglevel
 
 LOG = init_snapborg_logger(__name__)
 
@@ -47,6 +47,7 @@ def main():
     cli.add_argument("--dryrun", action="store_true", help="Don't actually execute commands")
     cli.add_argument("--snapper-config", default=None, dest="snapper_config",
                      help="The name of a snapper config to operate on")
+    cli.add_argument("-v", action="count", default=0, help="increase verbosity, can be repeated twice")
     subp = cli.add_subparsers(dest="mode", required=True)
 
     subp.add_parser("prune", help="Prune the borg archives using the retention settings from the "
@@ -66,6 +67,7 @@ def main():
                     "user data")
 
     args = cli.parse_args()
+    set_loglevel(args.v)
 
     with open(args.cfg, 'r') as stream:
         cfg = selective_merge(yaml.safe_load(stream), DEFAULT_CONFIG)

--- a/snapborg/snapper.py
+++ b/snapborg/snapper.py
@@ -5,6 +5,9 @@ from contextlib import contextmanager
 
 from packaging import version
 
+from .util import init_snapborg_logger
+
+LOG = init_snapborg_logger(__name__)
 
 def check_snapper():
     """
@@ -34,7 +37,7 @@ def run_snapper(args, config: str = None, dryrun=False):
         *args
     ]
     if dryrun:
-        print(args_new)
+        LOG.info(args_new)
         return None
     else:
         output = subprocess.check_output(args_new).decode().strip()
@@ -66,7 +69,7 @@ class SnapperConfig:
     @classmethod
     def get(cls, config_name: str):
         return cls(config_name, run_snapper(["get-config"], config_name))
-    
+
     @contextmanager
     def prevent_cleanup(self, snapshots=None, dryrun=False):
         """
@@ -78,7 +81,7 @@ class SnapperConfig:
 
         for s in snapshots:
             s.prevent_cleanup(dryrun=dryrun)
-        
+
         try:
             yield self
         finally:

--- a/snapborg/util.py
+++ b/snapborg/util.py
@@ -1,4 +1,7 @@
 import logging
+import os
+import sys
+
 
 def selective_merge(base_obj, delta_obj, restrict_keys=False):
     """
@@ -65,10 +68,27 @@ def split(data, pred):
     return (yes, no)
 
 
+def set_loglevel(verbosity_level):
+    loglevel = logging.WARNING
+    if verbosity_level > 0:
+        loglevel = logging.INFO
+        if verbosity_level > 1:
+            loglevel = logging.DEBUG
+
+    for logger_name in logging.root.manager.loggerDict:
+        logging.getLogger(logger_name).setLevel(loglevel)
+    return loglevel
+
+
 def init_snapborg_logger(logger_name):
+    is_interactive = os.isatty(sys.stdout.fileno())
     logger = logging.getLogger(logger_name)
-    logger.setLevel("INFO")
-    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    logger.setLevel(logging.INFO)
+    if is_interactive:
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    else:
+        # if running in non-interactive mode, typically through systemd
+        formatter = logging.Formatter("%(levelname)s - %(name)s:%(lineno)d - %(message)s")
     ch = logging.StreamHandler()
     ch.setFormatter(formatter)
     logger.addHandler(ch)

--- a/snapborg/util.py
+++ b/snapborg/util.py
@@ -1,3 +1,5 @@
+import logging
+
 def selective_merge(base_obj, delta_obj, restrict_keys=False):
     """
     Recursively merge dict delta_obj into base_obj by adding all key/value
@@ -61,3 +63,13 @@ def split(data, pred):
         else:
             no.append(d)
     return (yes, no)
+
+
+def init_snapborg_logger(logger_name):
+    logger = logging.getLogger(logger_name)
+    logger.setLevel("INFO")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    ch = logging.StreamHandler()
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+    return logger


### PR DESCRIPTION
A few changes and adjustments to error handing in `commands/snapborg:backup` function. I'm afraid it's still not perfect: a classic issue I see with exceptions is that they are caught too soon/hidden. While it makes sense to catch things in this context (we want to do all backups regardless of individual failures), borg's error message itself should be logged, ideally with the traceback pointing to `launch_borg`.

I don't want to spend too much time on this aspect of the code so this will have to do.