### PR TITLE
snapper.py: Do not prevent clean-up upon empty snapshot list

### DIFF
--- a/snapborg/snapper.py
+++ b/snapborg/snapper.py
@@ -73,7 +73,7 @@ class SnapperConfig:
         Return a context manager for this snapper config where each snapshot
         is prevented from being cleaned up by the timeline cleanup process
         """
-        if not snapshots:
+        if snapshots is None:
             snapshots = self.get_snapshots()
 
         for s in snapshots:


### PR DESCRIPTION
In Python, `not []` evaluates to `True`.  When the `snapshots` argument to the `prevent_cleanup` function is an empty list (which is not `None`), `if not snapshots` would prevent every snapshot's clean-up. The output of `snapborg --dryrun backup` clearly shows this:

    Backing up snapshots for snapper config 'boot'...
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '1']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '77']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '245']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '413']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '437']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '461']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '485']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '509']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '533']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '557']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '558']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', '', '559']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '1']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '77']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '245']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '413']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '437']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '461']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '485']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '509']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '533']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '557']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '558']
    ['snapper', '-c', 'boot', '--jsonout', 'modify', '--cleanup-algorithm', 'timeline', '559']

    Backup results:
    OK     boot

These Snapper invocations are redundant, as only snapshots that are selected for backup need clean-up prevention during Borg execution. This commit eliminates these redundant Snapper invocations.