### PR TITLE
Let `borg prune` list pruned and retained archives upon snapborg's prune operation

### DIFF
--- a/snapborg/borg.py
+++ b/snapborg/borg.py
@@ -81,7 +81,7 @@ class BorgRepo:
 
     def prune(self, override_retention_settings=None, dryrun=False):
         override_retention_settings = override_retention_settings or {}
-        borg_prune_invocation = ["prune"]
+        borg_prune_invocation = ["prune", "--list"]
         retention_settings = selective_merge(
             override_retention_settings, self.retention, restrict_keys=True)
         for name, value in retention_settings.items():


### PR DESCRIPTION
This commit allows users to know which archives are kept and which are pruned when they run `snapborg backup` or `snapborg prune` by enabling more verbose output like:

```console
# snapborg prune
$ borg prune --list --keep-monthly 0 --keep-yearly 0 --keep-hourly 0 --keep-daily 3 --keep-last 0 --keep-weekly 1 /tmp/snapborg-test
Keeping archive (rule: daily #1):        boot-714-2023-03-11T13:00:06         ...
Keeping archive (rule: daily #2):        boot-677-2023-03-10T00:00:10         ...
Keeping archive (rule: daily #3):        boot-653-2023-03-09T00:00:23         ...
Pruning archive (1/6):                   boot-629-2023-03-08T00:00:13         ...
Pruning archive (2/6):                   boot-605-2023-03-07T00:00:00         ...
Pruning archive (3/6):                   boot-581-2023-03-06T00:00:20         ...
Keeping archive (rule: weekly #1):       boot-557-2023-03-05T00:00:34         ...
Pruning archive (4/6):                   boot-413-2023-02-27T00:00:17         ...
Pruning archive (5/6):                   boot-245-2023-02-20T00:00:01         ...
Pruning archive (6/6):                   boot-77-2023-02-13T00:00:02          ...
```