### PR TITLE
Ignore `borg prune` error in fault tolerant mode

### DIFF
--- a/snapborg/commands/snapborg.py
+++ b/snapborg/commands/snapborg.py
@@ -230,7 +230,11 @@ def backup_candidate(snapper_config, borg_repo, candidate, recreate,
 
 def prune(cfg, snapper_configs, dryrun):
     for config in snapper_configs:
-        BorgRepo.create_from_config(config).prune(dryrun=dryrun)
+        try:
+            BorgRepo.create_from_config(config).prune(dryrun=dryrun)
+        except subprocess.CalledProcessError:
+            if not config["fault_tolerant_mode"]:
+                raise
 
 
 def init(cfg, snapper_configs, dryrun):


### PR DESCRIPTION
The fault tolerant mode would only ignore backup errors.  Pruning may also result in an error when the backup destination is unavailable, and the fault tolerant mode should cover this situation too.