### PR TITLE
Adds support for repokey-blake2 encryption

### DIFF
--- a/snapborg/borg.py
+++ b/snapborg/borg.py
@@ -114,7 +114,7 @@ class BorgRepo:
         password = None
         if encryption == "none":
             pass
-        elif encryption == "repokey":
+        elif encryption == "repokey" or encryption == "repokey-blake2":
             password = get_password(config["storage"]["encryption_passphrase"])
         else:
             raise Exception("Invalid or unsupported encryption mode given!")


### PR DESCRIPTION
Fixed issue https://github.com/enzingerm/snapborg/issues/29
- Blake2b can be faster on newer machines than SHA256
- Changing one line allows the tool to use it if the user wishes