### PR TITLE
Allow using bind mounts when backing up

### DIFF
--- a/snapborg/borg.py
+++ b/snapborg/borg.py
@@ -65,21 +65,24 @@ class BorgRepo:
             borg_create.append("--progress")
 
         repospec = f"{self.repopath}::{backup_name}"
+        args = borg_create + [repospec, '.']
 
         if mount_path is not None:
             with bind_mount(mount_path, path):
                 launch_borg(
-                    borg_create + [repospec, mount_path],
+                    args,
                     self.passphrase,
                     print_output=self.is_interactive,
                     dryrun=dryrun,
+                    cwd=mount_path,
                 )
         else:
             launch_borg(
-                borg_create + [repospec, path],
+                args,
                 self.passphrase,
                 print_output=self.is_interactive,
                 dryrun=dryrun,
+                cwd=path,
             )
 
     def delete(self, backup_name, dryrun=False):

--- a/snapborg/borg.py
+++ b/snapborg/borg.py
@@ -1,6 +1,8 @@
 import os
+import os.path
 import subprocess
 import sys
+from contextlib import contextmanager
 from subprocess import CalledProcessError
 
 from .util import restrict_keys, selective_merge
@@ -46,7 +48,7 @@ class BorgRepo:
         launch_borg(borg_init_invocation, self.passphrase,
                     print_output=self.is_interactive, dryrun=dryrun)
 
-    def backup(self, backup_name, *paths, exclude_patterns=[], timestamp=None, dryrun=False, cwd=None):
+    def backup(self, backup_name, path, exclude_patterns=[], timestamp=None, dryrun=False, mount_path=None):
 
         borg_create = ["create",
                        "--one-file-system",
@@ -63,15 +65,22 @@ class BorgRepo:
             borg_create.append("--progress")
 
         repospec = f"{self.repopath}::{backup_name}"
-        borg_invocation = borg_create + [repospec, *paths]
 
-        launch_borg(
-            borg_invocation,
-            self.passphrase,
-            print_output=self.is_interactive,
-            dryrun=dryrun,
-            cwd=cwd
-        )
+        if mount_path is not None:
+            with bind_mount(mount_path, path):
+                launch_borg(
+                    borg_create + [repospec, mount_path],
+                    self.passphrase,
+                    print_output=self.is_interactive,
+                    dryrun=dryrun,
+                )
+        else:
+            launch_borg(
+                borg_create + [repospec, path],
+                self.passphrase,
+                print_output=self.is_interactive,
+                dryrun=dryrun,
+            )
 
     def delete(self, backup_name, dryrun=False):
         borg_delete = ["delete", f"{self.repopath}::{backup_name}"]
@@ -169,3 +178,22 @@ def launch_borg(args, password=None, print_output=False, dryrun=False, cwd=None)
                     print(f"Borg command execution gave warnings:\n{e.output.decode()}")
             else:
                 raise
+
+
+@contextmanager
+def bind_mount(mount_path, target_path):
+    """
+    Creates a bind mount mounted at mount_path pointing to target_path.  Usually requires root privileges.
+    """
+
+    os.makedirs(mount_path, exist_ok=True)
+
+    # If we didn't properly clean this up in previous invocations
+    while os.path.ismount(mount_path):
+        subprocess.check_call(['umount', mount_path])
+
+    subprocess.check_call(['mount', '--bind', target_path, mount_path])
+    try:
+        yield
+    finally:
+        subprocess.check_call(['umount', mount_path])

--- a/snapborg/commands/snapborg.py
+++ b/snapborg/commands/snapborg.py
@@ -190,7 +190,7 @@ def backup_config(config, recreate, dryrun, bind_mount):
             **retention_config) if(not snapshot.is_backed_up() or recreate)
     ]
 
-    mount_path = f'/var/run/snapborg/{name}' if bind_mount else None
+    mount_path = f'/run/snapborg/{name}' if bind_mount else None
 
     with snapper_config.prevent_cleanup(snapshots=candidates, dryrun=dryrun):
         results = [ backup_candidate(snapper_config, repo, candidate, recreate,


### PR DESCRIPTION
Before this PR, snapborg uses whatever is the "real path" of a snapshot to perform the backup.  However, it turns out that borg uses the full canonical path of backed-up files when populating the file cache.

By using bind mounts, we can ensure that the path is always the same.  This PR adds a flag which always bind mounts the snapshot under `/var/run/snapborg/<config>` before performing a backup.  This increases the cache hit rate by a lot when running regular backups.