### PR TITLE
Detect permission error and warn about re-running as root

### DIFF
--- a/snapborg/borg.py
+++ b/snapborg/borg.py
@@ -189,7 +189,10 @@ def bind_mount(mount_path, target_path):
     Creates a bind mount mounted at mount_path pointing to target_path.  Usually requires root privileges.
     """
 
-    os.makedirs(mount_path, exist_ok=True)
+    try:
+        os.makedirs(mount_path, exist_ok=True)
+    except PermissionError as exc:
+        raise Exception("Failed to create bind mount dir; most likely you should re-run this command as root") from exc
 
     # If we didn't properly clean this up in previous invocations
     while os.path.ismount(mount_path):


### PR DESCRIPTION
Follow up commit from my last PR #31 that just got merged:

> Maybe the error handling could be refined because if run as non-root, the first os.makedirs call would just raise an exception.

Gonna dwell on this for a bit to figure out what to do.  Conceivably the `snapborg` binary could be setuid to root, or somebody might set up a special `snapborg` user that has write access to the `/run/snapborg` dir and so on.  Actually I thought about doing that with the systemd units PR, but I couldn't find a way to reliably ensure/create a specific user in `setup.py`.

So in other words, I could add a check for `os.geteuid()` here, but the dir might still be writable despite running as a different user.

I added a commit which does the "ask for forgiveness not permission" thing for now though.

I see you merged the PR, so this will end up in a new PR :)