### PR TITLE
Preserve errors/causal chain in case of failure

### DIFF
--- a/snapborg/commands/snapborg.py
+++ b/snapborg/commands/snapborg.py
@@ -147,16 +147,18 @@ def backup(cfg, snapper_configs, recreate, prune_old_backups, dryrun, bind_mount
         except Exception as e:
             status_map[config["name"]] = e
     print("\nBackup results:")
-    has_error = False
+    errors = []
     for config_name, status in status_map.items():
         if status is True:
             print(f"OK     {config_name}")
         else:
-            has_error = True
+            errors.append(status)
             print(f"FAILED {config_name}: {status}")
 
-    if has_error:
-        raise Exception("Snapborg failed!")
+    if len(errors) == 1:
+        raise Exception("Snapborg failed!") from errors[0]
+    elif len(errors) > 1:
+        raise Exception("Snapborg failed!") from ExceptionGroup("Multiple configs failed", errors)
     elif prune_old_backups:
         prune(cfg, snapper_configs, dryrun)
 


### PR DESCRIPTION
I found my backups were broken and tried to debug why they were failing, and I saw messages like:

```
Started Run snapborg backup (and prune) for the 'root' snapper config.
Backing up snapshots for snapper config 'root'...
Backup results:
FAILED root: year 0 is out of range
Traceback (most recent call last):
  File "/usr/bin/snapborg", line 33, in <module>
    sys.exit(load_entry_point('snapborg==0.1.0', 'console_scripts', 'snapborg')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/snapborg/commands/snapborg.py", line 82, in main
    backup(cfg, snapper_configs=configs, recreate=args.recreate,
  File "/usr/lib/python3.12/site-packages/snapborg/commands/snapborg.py", line 159, in backup
    raise Exception("Snapborg failed!")
Exception: Snapborg failed!
snapborg-backup@root.service: Main process exited, code=exited, status=1/FAILURE
snapborg-backup@root.service: Failed with result 'exit-code'.
```

...which gave me no idea what was actually causing the error.

With this change, we preserve the full stack trace of the underlying error, giving me this instead:

```
Started Run snapborg backup (and prune) for the 'root' snapper config.
Backing up snapshots for snapper config 'root'...
Backup results:
FAILED root: year 0 is out of range
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/snapborg/commands/snapborg.py", line 145, in backup
    backup_config(config, recreate, dryrun, bind_mount)
  File "/usr/lib/python3.12/site-packages/snapborg/commands/snapborg.py", line 190, in backup_config
    for snapshot in get_retained_snapshots(
                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/snapborg/retention.py", line 56, in get_retained_snapshots
    interval = (prev_date_fn(interval[0]), interval[0])
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/snapborg/retention.py", line 34, in <lambda>
    (keep_yearly, lambda x: datetime(x.year - 1, 1, 1), datetime(today.year, 1, 1))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: year 0 is out of range
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/usr/bin/snapborg", line 33, in <module>
    sys.exit(load_entry_point('snapborg==0.1.0', 'console_scripts', 'snapborg')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/snapborg/commands/snapborg.py", line 82, in main
    backup(cfg, snapper_configs=configs, recreate=args.recreate,
  File "/usr/lib/python3.12/site-packages/snapborg/commands/snapborg.py", line 159, in backup
    raise Exception("Snapborg failed!") from errors[0]
Exception: Snapborg failed!
snapborg-backup@root.service: Main process exited, code=exited, status=1/FAILURE
snapborg-backup@root.service: Failed with result 'exit-code'.
```

...which gave me a starting point for how to fix this bug (a follow-up PR will hopefully come soon)