### PR TITLE
Preserve env vars when calling borg

### DIFF
--- a/snapborg/borg.py
+++ b/snapborg/borg.py
@@ -169,7 +169,12 @@ def launch_borg(args, password=None, print_output=False, dryrun=False, cwd=None)
         print(f"$ {' '.join(cmd)}")
 
     if not dryrun:
-        env = {'BORG_PASSPHRASE': password} if password else {}
+        # Start with a copy of the current environment
+        env = os.environ.copy()
+
+        if password:
+            env['BORG_PASSPHRASE'] = password
+
         # TODO: parse output from JSON log lines
         try:
             if print_output:


### PR DESCRIPTION
This allows variables like BORG_REMOTE_PATH to be passed to the borg process, for example with a a systemd override unit.

/etc/systemd/system/snapborg-backup-all.service.d/environment.conf

```
[Service]
Environment="BORG_REMOTE_PATH=borg14"
```

https://borgbackup.readthedocs.io/en/stable/usage/general.html#environment-variables

This resolves #19 