### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Nix
+result

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  pkgs,
+  pythonPackages,
+  src,
+  ...
+}:
+let
+  version_file = builtins.readFile "${src}/snapborg/version.py";
+  version_match = builtins.match ".*__version__ = \"([0-9A-Za-z.+-]+)\".*" version_file;
+  version = builtins.head version_match;
+in
+pythonPackages.buildPythonApplication rec {
+  pname = "snapborg";
+  pyproject = true;
+  inherit src;
+  inherit version;
+
+  propagatedBuildInputs = with pkgs; [
+    borgbackup
+    snapper
+    pythonPackages.pyyaml
+  ];
+
+  nativeBuildInputs = with pythonPackages; [
+    setuptools
+    packaging
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/enzingerm/snapborg";
+    license = licenses.gpl3;
+  };
+}


### PR DESCRIPTION
This PR makes it possible to install `snapborg` as a [nix](https://nixos.org/) package.

Ideally, I want to implement a proper nix wrapper, so `snapborg.yml` will also be generated.